### PR TITLE
Feature/experimental field size limit

### DIFF
--- a/cmd/nitrite/main.go
+++ b/cmd/nitrite/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/blocky/nitrite"
+	"github.com/hf/nitrite"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
-module github.com/blocky/nitrite
+module github.com/hf/nitrite
 
 go 1.17
 
 require (
 	github.com/fxamacker/cbor/v2 v2.4.0
-	github.com/blocky/nitrite v0.0.0
+	github.com/hf/nitrite v0.0.0
 )
 
 require github.com/x448/float16 v0.8.4 // indirect

--- a/nitrite.go
+++ b/nitrite.go
@@ -128,7 +128,7 @@ var (
 	ErrCOSESign1BadAlgorithm          error = errors.New("COSESign1 algorithm not ECDSA384")
 )
 
-// Errors encountered when parsing the CoseBytes attestation document.
+// Errors encountered when parsing the CBOR attestation document.
 var (
 	ErrBadAttestationDocument error = errors.New("Bad attestation document")
 	ErrMandatoryFieldsMissing error = errors.New("One or more of mandatory fields missing")

--- a/nitrite.go
+++ b/nitrite.go
@@ -104,21 +104,6 @@ type coseSignature struct {
 	Payload     []byte
 }
 
-// Size of these fields (in bytes) comes from AWS Nitro documentation at
-// https://docs.aws.amazon.com/enclaves/latest/user/enclaves-user.pdf
-// from May 4, 2022.
-// With maxNonceLen = 1024, maxUserDataLen = 1024, and maxPublicKeyLen = 1024
-// the total AttestationLen = 6591.
-// An experiment on August 8, 2022, allowed user data to be maximized to
-// maxUserDataLen = 3868 with maxNonceLen = 40 and maxPublicKeyLen = 1024 for
-// the total AttestationLen = 8451.
-const (
-	maxNonceLen       = 1024
-	maxUserDataLen    = 1024
-	maxPublicKeyLen   = 1024
-	MaxAttestationLen = 6591
-)
-
 // Errors that are encountered when manipulating the COSESign1 structure.
 var (
 	ErrBadCOSESign1Structure          error = errors.New("Data is not a COSESign1 array")
@@ -137,10 +122,11 @@ var (
 	ErrBadPCRs                          error = errors.New("Payload 'pcrs' is less than 1 or more than 32")
 	ErrBadPCRIndex                      error = errors.New("Payload 'pcrs' key index is not in [0, 32)")
 	ErrBadPCRValue                      error = errors.New("Payload 'pcrs' value is nil or not of length {32,48,64}")
+	ErrBadCABundle                      error = errors.New("Payload 'cabundle' has 0 elements")
 	ErrBadCABundleItem                  error = errors.New("Payload 'cabundle' has a nil item or of length not in [1, 1024]")
-	ErrBadPublicKey                     error = fmt.Errorf("Payload 'public_key' has a value of length not in [1, %d]", maxPublicKeyLen)
-	ErrBadUserData                      error = fmt.Errorf("Payload 'user_data' has a value of length not in [1, %d]", maxUserDataLen)
-	ErrBadNonce                         error = fmt.Errorf("Payload 'nonce' has a value of length not in [1, %d]", maxNonceLen)
+	ErrBadPublicKey                     error = errors.New("Payload 'public_key' has a value of length not in [1, 1024]")
+	ErrBadUserData                      error = errors.New("Payload 'user_data' has a value of length not in [1, 512]")
+	ErrBadNonce                         error = errors.New("Payload 'nonce' has a value of length not in [1, 512]")
 	ErrBadCertificatePublicKeyAlgorithm error = errors.New("Payload 'certificate' has a bad public key algorithm (not ECDSA)")
 	ErrBadCertificateSigningAlgorithm   error = errors.New("Payload 'certificate' has a bad public key signing algorithm (not ECDSAWithSHA384)")
 	ErrBadSignature                     error = errors.New("Payload's signature does not match signature from certificate")
@@ -290,10 +276,9 @@ func Verify(data []byte, options VerifyOptions) (*Result, error) {
 		}
 	}
 
-	// turn of this check for self-signed certificates
-	//if !options.AllowSelfSignedCert && len(doc.CABundle) < 1 {
-	//	return nil, ErrBadCABundle
-	//}
+	if !options.AllowSelfSignedCert && len(doc.CABundle) < 1 {
+		return nil, ErrBadCABundle
+	}
 
 	if !options.AllowSelfSignedCert {
 		for _, item := range doc.CABundle {
@@ -303,16 +288,17 @@ func Verify(data []byte, options VerifyOptions) (*Result, error) {
 		}
 	}
 
-	if nil != doc.PublicKey && (len(doc.PublicKey) < 1 ||
-		len(doc.PublicKey) > maxPublicKeyLen) {
+	// Size of these fields comes from AWS Nitro documentation at
+	// https://docs.aws.amazon.com/enclaves/latest/user/enclaves-user.pdf
+	// from May 4, 2022. Experimentally verified values August 8, 2022, allow
+	// UserData limit of 3866B with a Nonce of 42B.
+	if nil != doc.PublicKey && (len(doc.PublicKey) < 1 || len(doc.PublicKey) > 1024) {
 		return nil, ErrBadPublicKey
 	}
-	if nil != doc.UserData && (len(doc.UserData) < 1 ||
-		len(doc.UserData) > maxUserDataLen) {
+	if nil != doc.UserData && (len(doc.UserData) < 1 || len(doc.UserData) > 1024) {
 		return nil, ErrBadUserData
 	}
-	if nil != doc.Nonce && (len(doc.Nonce) < 1 ||
-		len(doc.Nonce) > maxNonceLen) {
+	if nil != doc.Nonce && (len(doc.Nonce) < 1 || len(doc.Nonce) > 1024) {
 		return nil, ErrBadNonce
 	}
 

--- a/nitrite.go
+++ b/nitrite.go
@@ -140,15 +140,15 @@ var (
 	ErrBadCABundle            error = errors.New("Payload 'cabundle' has 0 elements")
 	ErrBadCABundleItem        error = errors.New("Payload 'cabundle' has a nil item or of length not in [1, 1024]")
 	ErrBadPublicKey           error = fmt.Errorf(
-		"Payload 'public_key' has a value of length not in [1, %d]",
+		"Payload 'public_key' length greater than %d",
 		maxPublicKeyLen,
 	)
 	ErrBadUserData error = fmt.Errorf(
-		"Payload 'user_data' has a value of length not in [1, %d]",
+		"Payload 'user_data' length greater than %d",
 		maxUserDataLen,
 	)
 	ErrBadNonce error = fmt.Errorf(
-		"Payload 'nonce' has a value of length not in [1, %d]",
+		"Payload 'nonce' length greater than %d",
 		maxNonceLen,
 	)
 	ErrBadCertificatePublicKeyAlgorithm error = errors.New("Payload 'certificate' has a bad public key algorithm (not ECDSA)")
@@ -330,16 +330,13 @@ func Verify(data []byte, options VerifyOptions) (*Result, error) {
 		}
 	}
 
-	if nil != doc.PublicKey && (len(doc.PublicKey) < 1 ||
-		len(doc.PublicKey) > maxPublicKeyLen) {
+	if nil != doc.PublicKey && len(doc.PublicKey) > maxPublicKeyLen {
 		return nil, ErrBadPublicKey
 	}
-	if nil != doc.UserData && (len(doc.UserData) < 1 ||
-		len(doc.UserData) > maxUserDataLen) {
+	if nil != doc.UserData && len(doc.UserData) > maxUserDataLen {
 		return nil, ErrBadUserData
 	}
-	if nil != doc.Nonce && (len(doc.Nonce) < 1 ||
-		len(doc.Nonce) > maxNonceLen) {
+	if nil != doc.Nonce && len(doc.Nonce) > maxNonceLen {
 		return nil, ErrBadNonce
 	}
 

--- a/nitrite.go
+++ b/nitrite.go
@@ -291,9 +291,10 @@ func Verify(data []byte, options VerifyOptions) (*Result, error) {
 		}
 	}
 
-	if !options.AllowSelfSignedCert && len(doc.CABundle) < 1 {
-		return nil, ErrBadCABundle
-	}
+	// turn of this check for self-signed certificates
+	//if !options.AllowSelfSignedCert && len(doc.CABundle) < 1 {
+	//	return nil, ErrBadCABundle
+	//}
 
 	if !options.AllowSelfSignedCert {
 		for _, item := range doc.CABundle {

--- a/nitrite.go
+++ b/nitrite.go
@@ -137,7 +137,6 @@ var (
 	ErrBadPCRs                          error = errors.New("Payload 'pcrs' is less than 1 or more than 32")
 	ErrBadPCRIndex                      error = errors.New("Payload 'pcrs' key index is not in [0, 32)")
 	ErrBadPCRValue                      error = errors.New("Payload 'pcrs' value is nil or not of length {32,48,64}")
-	ErrBadCABundle                      error = errors.New("Payload 'cabundle' has 0 elements")
 	ErrBadCABundleItem                  error = errors.New("Payload 'cabundle' has a nil item or of length not in [1, 1024]")
 	ErrBadPublicKey                     error = fmt.Errorf("Payload 'public_key' has a value of length not in [1, %d]", maxPublicKeyLen)
 	ErrBadUserData                      error = fmt.Errorf("Payload 'user_data' has a value of length not in [1, %d]", maxUserDataLen)

--- a/nitrite.go
+++ b/nitrite.go
@@ -192,24 +192,6 @@ func reverse(enc []byte) []byte {
 	return rev
 }
 
-func CoseToDocument(coseBytes []byte) (Document, error) {
-	cose := CosePayload{}
-
-	err := cbor.Unmarshal(coseBytes, &cose)
-	if nil != err {
-		return Document{}, ErrBadCOSESign1Structure
-	}
-
-	attestDoc := Document{}
-
-	err = cbor.Unmarshal(cose.Payload, &attestDoc)
-	if nil != err {
-		return Document{}, ErrBadAttestationDocument
-	}
-
-	return attestDoc, nil
-}
-
 // Verify verifies the attestation payload from `data` with the provided
 // verification options. If the options specify `Roots` as `nil`, the
 // `DefaultCARoot` will be used. If you do not specify `CurrentTime`,

--- a/nitrite.go
+++ b/nitrite.go
@@ -104,6 +104,21 @@ type coseSignature struct {
 	Payload     []byte
 }
 
+// Size of these fields (in bytes) comes from AWS Nitro documentation at
+// https://docs.aws.amazon.com/enclaves/latest/user/enclaves-user.pdf
+// from May 4, 2022.
+// With maxNonceLen = 1024, maxUserDataLen = 1024, and maxPublicKeyLen = 1024
+// the total AttestationLen = 6591.
+// An experiment on August 8, 2022, allowed user data to be maximized to
+// maxUserDataLen = 3868 with maxNonceLen = 40 and maxPublicKeyLen = 1024 for
+// the total AttestationLen = 8451.
+const (
+	maxNonceLen       = 1024
+	maxUserDataLen    = 1024
+	maxPublicKeyLen   = 1024
+	MaxAttestationLen = 6591
+)
+
 // Errors that are encountered when manipulating the COSESign1 structure.
 var (
 	ErrBadCOSESign1Structure          error = errors.New("Data is not a COSESign1 array")
@@ -124,31 +139,13 @@ var (
 	ErrBadPCRValue                      error = errors.New("Payload 'pcrs' value is nil or not of length {32,48,64}")
 	ErrBadCABundle                      error = errors.New("Payload 'cabundle' has 0 elements")
 	ErrBadCABundleItem                  error = errors.New("Payload 'cabundle' has a nil item or of length not in [1, 1024]")
-	ErrBadPublicKey                     error = errors.New("Payload 'public_key' has a value of length not in [1, 1024]")
-	ErrBadUserData                      error = errors.New("Payload 'user_data' has a value of length not in [1, 512]")
-	ErrBadNonce                         error = errors.New("Payload 'nonce' has a value of length not in [1, 512]")
+	ErrBadPublicKey                     error = fmt.Errorf("Payload 'public_key' has a value of length not in [1, %d]", maxPublicKeyLen)
+	ErrBadUserData                      error = fmt.Errorf("Payload 'user_data' has a value of length not in [1, %d]", maxUserDataLen)
+	ErrBadNonce                         error = fmt.Errorf("Payload 'nonce' has a value of length not in [1, %d]", maxNonceLen)
 	ErrBadCertificatePublicKeyAlgorithm error = errors.New("Payload 'certificate' has a bad public key algorithm (not ECDSA)")
 	ErrBadCertificateSigningAlgorithm   error = errors.New("Payload 'certificate' has a bad public key signing algorithm (not ECDSAWithSHA384)")
 	ErrBadSignature                     error = errors.New("Payload's signature does not match signature from certificate")
 	ErrMarshallingCoseSignature         error = errors.New("Could not marshal COSE signature")
-)
-
-// Size of these fields comes from AWS Nitro documentation at
-// https://docs.aws.amazon.com/enclaves/latest/user/enclaves-user.pdf
-// from May 4, 2022.
-// With maxNonceLen = 1024, maxUserDataLen = 1024, and maxPublicKeyLen = 1024
-// the total AttestationLen = ???.
-// An experiment on August 8, 2022, allowed user data to be maximized to
-// maxUserDataLen = 3866 with maxNonceLen = 42 and maxPublicKeyLen = 1024 for
-// the total AttestationLen = ???.
-
-// UserData limit of 3866B with a Nonce of 42B and key size of 1024.
-// The total observed attestation size was 5850? //todo: finish this
-const (
-	maxNonceLen       = 1024
-	maxUserDataLen    = 1024
-	maxPublicKeyLen   = 1024
-	MaxAttestationLen = 5000
 )
 
 const (


### PR DESCRIPTION
This PR makes small changes to the repo to check attestation field size limits against experimental values.

There is more that needs to be refactored in this package. This PR incorporates the working changes for now, so that the sequencer doesn't need to replace nitrite from a local directory.

For context, the point of having our own version of nitrite is not so much the custom field sizes (we only use the public key field of an attestation), but to allow checking of attestations made by the StandaloneAttester with a self-signed key.