### PR TITLE
Update PCR length

### DIFF
--- a/nitrite.go
+++ b/nitrite.go
@@ -285,7 +285,11 @@ func Verify(data []byte, options VerifyOptions) (*Result, error) {
 			return nil, ErrBadPCRIndex
 		}
 
-		if nil == value || !(32 == len(value) || 48 == len(value) || 64 == len(value)) {
+		if nil == value ||
+			!(32 == len(value) ||
+				48 == len(value) ||
+				64 == len(value) ||
+				96 == len(value)) {
 			return nil, ErrBadPCRValue
 		}
 	}


### PR DESCRIPTION
Allow for 96 byte PCRs as defined in https://docs.aws.amazon.com/enclaves/latest/user/set-up-attestation.html